### PR TITLE
Query Updates: Code cleanup, new functionality

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,10 +59,14 @@ last part of that ARN (user/... or role/...).
 
 ### Presets
 
-The existing preset is `priv_esc` or `change_perms`, which have the same 
-function. They describe which principals have the ability to change their own 
-permissions. If a principal is able to change their own perms, then it 
-effectively has unlimited perms.
+There are two presets. The first is `priv_esc`, which is also available as 
+`privesc` or `change_perms`. It identifies all principals that can change 
+their own permissions (dubbed as admins) directly. Then it identifies any 
+principals that can access the administrative principals (potential privilege 
+escalation risks).
+
+The other preset is `connected`. It identifies if one principal can access 
+another, or list all principals that can be accessed.
 
 ## Visualizing
 
@@ -75,7 +79,7 @@ To create the DOT and SVG files, run the command:
 Currently the output is a directed graph, which collates all the edges with 
 the same source and destination nodes. It does not draw edges where the source 
 is an admin. Nodes for admins are colored blue. Nodes for users with the 
-ability to access admins are colored red (potential priv-esc risk).
+ability to access admins are colored red (potential priv-esc risks).
 
 ## Sample Output
 
@@ -152,7 +156,6 @@ user/PowerUser can change privileges because:
 
 * Complete and verify Python 3 support.
 * Smarter control over rate of API requests (Queue, managing throttles).
-* Better progress reporting.
 * Validate and add more checks for obtaining credentials. Several services use
 service roles that grant the service permission to do an action within a user's 
 account. This could potentially allow a user to obtain access to additional 
@@ -163,6 +166,5 @@ privileges.
 * Adding more caching. 
 * Local policy evaluation?
 * Cross-account subcommand(s).
-* A preset to check if one principal is connected to another.
 * Handling policies for buckets or keys with services like S3 or KMS when 
 querying.

--- a/pmapper.py
+++ b/pmapper.py
@@ -39,6 +39,7 @@ def main():
         description='Uses a created graph to provide a query interface, executes the passed query. It also will make calls to the AWS API.'
     )
     queryparser.add_argument('query_string', help='The query to run against the endpoint.')
+    queryparser.add_argument('-s', '--skip-admin', action='store_true', help='Skip admin principals when running a query.')
     visualparser = subparsers.add_parser(
         'visualize',
         help='For visualizing the pulled graph.',
@@ -91,7 +92,7 @@ def handle_query(parsed):
         print('Exiting.')
         sys.exit(-1)
 
-    perform_query(parsed.query_string, botocore_session, graph)
+    perform_query(parsed.query_string, botocore_session, graph, parsed.skip_admin)
 
 
 def handle_visualize(parsed):

--- a/principalmap/queries/privesc.py
+++ b/principalmap/queries/privesc.py
@@ -51,12 +51,12 @@ class PrivEscQuery:
 
     @staticmethod
     def explain_path(nodeO, tupleX):
-        result = str(nodeO) + " can change privileges because:\n"
+        result = str(nodeO) + " can escalate privileges because:\n"
 
         result += '   ' + str(nodeO) + ' can access ' + str(tupleX[0]) + " because: \n"
         for edge in tupleX[1]:
             result += '      ' + str(edge.nodeX) + ' ' + edge.longlabel + ' ' + str(edge.nodeY) + "\n"
-        result += '   and ' + str(tupleX[0]) + ' can change its own privileges.'
+        result += '   and ' + str(tupleX[0]) + ' can escalate its own privileges.'
 
         return result
 
@@ -76,7 +76,7 @@ class PrivEscQuery:
     @staticmethod
     def print_help():
         print('PRIV ESC QUERY HELP:')
-        print('USAGE: ./principalmap query "(priv_esc|change_perms) <Principal ARN>"')
+        print('USAGE: ./principalmap query "(priv_esc|privesc|change_perms) <Principal ARN>"')
         print('WHERE:')
         print('   Principal ARN is the principal to check for "priv-esc" capabilities.')
         print('      (also accepts (user|role)/<principal_name>)')

--- a/principalmap/querying.py
+++ b/principalmap/querying.py
@@ -181,4 +181,5 @@ def query_syntax_and_exit():
     print('   <preset_name> is a predefined query with a set of args <preset_args>')
     print('PRESET QUERY LIST:')
     print('   * priv_esc (a.k.a. privesc or change_perms)')
+    print('   * connected')
     sys.exit(-1)


### PR DESCRIPTION
Queries are interpreted and launched from `/principalmap/querying.py`. This pull request pulls apart the giant function that did all the work and breaks it up for easier reading/writing in the future.

This adds a preset named "connected" (#2). It lets you see if a given node can access a target node, or list all the nodes that a given node can access.

This adds a new flag named "--skip-admin | -s" (#4). This flag let's you skip the obvious "yes the admin can do X" whenever you run a query for all the principals in an account.