### PR TITLE
Only one group is being checked for node with multiple group memberships

### DIFF
--- a/principalmapper/common/graphs.py
+++ b/principalmapper/common/graphs.py
@@ -179,7 +179,6 @@ class Graph(object):
             for group in groups:
                 if group.arn in node['group_memberships']:
                     group_memberships.append(group)
-                    break
             nodes.append(Node(arn=node['arn'], id_value=node['id_value'], attached_policies=node_policies,
                               group_memberships=group_memberships, trust_policy=node['trust_policy'],
                               instance_profile=node['instance_profile'], num_access_keys=node['access_keys'],


### PR DESCRIPTION
Invalid break only lets one group_membership for node while building graph, even-though there are multiple group_memberships for a node.

For example: userA has three groups Group A, Group B, Group C. Only  One Group out of three is being considered for node userA
