### PR TITLE
Merge in v1.1.5

### DIFF
--- a/principalmapper/__init__.py
+++ b/principalmapper/__init__.py
@@ -15,4 +15,4 @@
 #      You should have received a copy of the GNU Affero General Public License
 #      along with Principal Mapper.  If not, see <https://www.gnu.org/licenses/>.
 
-__version__ = '1.1.4'
+__version__ = '1.1.5'

--- a/principalmapper/graphing/gathering.py
+++ b/principalmapper/graphing/gathering.py
@@ -809,7 +809,7 @@ def update_admin_status(nodes: List[Node], scps: Optional[List[List[dict]]] = No
 
         # check if node can update an attached customer-managed policy (assumes SetAsDefault is set to True)
         for attached_policy in node.attached_policies:
-            if attached_policy.arn != node.arn:
+            if attached_policy.arn != node.arn and ':aws:policy/' not in attached_policy.arn:
                 if query_interface.local_check_authorization_handling_mfa(node, 'iam:CreatePolicyVersion',
                                                                           attached_policy.arn, {},
                                                                           service_control_policy_groups=scps)[0]:
@@ -829,7 +829,7 @@ def update_admin_status(nodes: List[Node], scps: Optional[List[List[dict]]] = No
                     node.is_admin = True
                     break  # as above
                 for attached_policy in group.attached_policies:
-                    if attached_policy.arn != group.arn:
+                    if attached_policy.arn != group.arn and ':aws:policy/' not in attached_policy.arn:
                         if query_interface.local_check_authorization_handling_mfa(node, 'iam:CreatePolicyVersion',
                                                                                   attached_policy.arn, {},
                                                                                   service_control_policy_groups=scps)[0]:

--- a/principalmapper/graphing/sts_edges.py
+++ b/principalmapper/graphing/sts_edges.py
@@ -39,7 +39,7 @@ class STSEdgeChecker(EdgeChecker):
         """Fulfills expected method return_edges. If the session object is None, performs checks in offline-mode"""
 
         result = generate_edges_locally(nodes, scps)
-        logging.info('Generating Edges based on STS')
+        logger.info('Generating Edges based on STS')
 
         for edge in result:
             logger.info("Found new edge: {}".format(edge.describe_edge()))

--- a/principalmapper/querying/presets/wrongadmin.py
+++ b/principalmapper/querying/presets/wrongadmin.py
@@ -1,0 +1,185 @@
+#  Copyright (c) NCC Group and Erik Steringer 2021. This file is part of Principal Mapper.
+#
+#      Principal Mapper is free software: you can redistribute it and/or modify
+#      it under the terms of the GNU Affero General Public License as published by
+#      the Free Software Foundation, either version 3 of the License, or
+#      (at your option) any later version.
+#
+#      Principal Mapper is distributed in the hope that it will be useful,
+#      but WITHOUT ANY WARRANTY; without even the implied warranty of
+#      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#      GNU Affero General Public License for more details.
+#
+#      You should have received a copy of the GNU Affero General Public License
+#      along with Principal Mapper.  If not, see <https://www.gnu.org/licenses/>.
+
+import copy
+import json
+import logging
+import re
+from typing import List, Dict, Tuple, Optional
+
+from principalmapper.common import Graph, Policy, Node
+from principalmapper.querying import query_interface
+from principalmapper.querying.local_policy_simulation import policy_has_matching_statement
+from principalmapper.util import arns
+from principalmapper.util.case_insensitive_dict import CaseInsensitiveDict
+
+
+logger = logging.getLogger(__name__)
+
+
+def handle_preset_query(graph: Graph, tokens: List[str], skip_admins: bool = False) -> None:
+    """Handles a human-readable query that's been chunked into tokens, and prints the results. Prints out the
+    principals in the account who are marked Admin but do not have the AdministratorAccess managed policy or an
+    inline equivalent.
+
+    Tokens should be:
+
+    * "preset"
+    * "wrongadmin"
+    """
+
+    wal = compose_wrong_admin_list(graph)
+    for node, reasons in wal:
+        print('{}'.format(node.searchable_name()))
+        for reason in reasons:
+            print('    * {}'.format(reason))
+        print()
+
+
+def _is_admin_or_equiv_policy(policy: Policy) -> bool:
+    """Given a Policy return true if the policy is the AdministratorAccess policy or if the policy document
+    is effectively the same."""
+
+    if ':aws:policy/AdministratorAccess' in policy.arn:
+        return True
+
+    for stmt in policy.policy_doc['Statement']:
+        action_flag, resource_flag = False, False
+        if 'Action' in stmt and 'Resource' in stmt and stmt['Effect'] == 'Allow':
+            if isinstance(stmt['Action'], str):
+                if stmt['Action'] == '*':
+                    action_flag = True
+            else:
+                for action in stmt['Action']:
+                    if action == '*':
+                        action_flag = True
+                        break
+
+            if isinstance(stmt['Resource'], str):
+                if stmt['Resource'] == '*':
+                    resource_flag = True
+            else:
+                for resource in stmt['Resource']:
+                    if resource == '*':
+                        resource_flag = True
+                        break
+        if action_flag and resource_flag:
+            return True
+
+    return False
+
+
+def _get_admin_reason(node: Node) -> List[str]:
+    """Return a list of reasons why this given node is an admin."""
+
+    result = []
+    logger.debug("Checking if {} is an admin".format(node.searchable_name()))
+    node_type = arns.get_resource(node.arn).split('/')[0]
+
+    # check if node can modify its own inline policies
+    if node_type == 'user':
+        action = 'iam:PutUserPolicy'
+    else:  # node_type == 'role'
+        action = 'iam:PutRolePolicy'
+    if query_interface.local_check_authorization_handling_mfa(node, action, node.arn, {})[0]:
+        result.append('Can call {} to add/update their own inline policies'.format(action))
+
+    # check if node can attach the AdministratorAccess policy to itself
+    if node_type == 'user':
+        action = 'iam:AttachUserPolicy'
+    else:
+        action = 'iam:AttachRolePolicy'
+    condition_keys = {'iam:PolicyARN': 'arn:aws:iam::aws:policy/AdministratorAccess'}
+    if query_interface.local_check_authorization_handling_mfa(node, action, node.arn, condition_keys)[0]:
+        result.append('Can call {} to attach the AdministratorAccess policy to itself'.format(action))
+
+    # check if node can create a role and attach the AdministratorAccess policy or an inline policy
+    if query_interface.local_check_authorization_handling_mfa(node, 'iam:CreateRole', '*', {})[0]:
+        if query_interface.local_check_authorization_handling_mfa(node, 'iam:AttachRolePolicy', '*',
+                                                                  condition_keys)[0]:
+            result.append('Can create an IAM Role (iam:CreateRole) and attach the AdministratorAccess policy to it (iam:AttachRolePolicy)'.format(action))
+        if query_interface.local_check_authorization_handling_mfa(node, 'iam:PutRolePolicy', '*', condition_keys)[0]:
+            result.append('Can create an IAM Role (iam:CreateRole) and create an inline policy for it (iam:PutRolePolicy)'.format(action))
+
+    # check if node can update an attached customer-managed policy (assumes SetAsDefault is set to True)
+    for attached_policy in node.attached_policies:
+        if attached_policy.arn != node.arn and ':aws:policy/' not in attached_policy.arn:
+            if query_interface.local_check_authorization_handling_mfa(node, 'iam:CreatePolicyVersion',
+                                                                      attached_policy.arn, {})[0]:
+                result.append('Can modify the attached managed policy {} (iam:CreatePolicyVersion)'.format(attached_policy.arn))
+                break  # reduce output
+
+    # check if node is a user, and if it can attach or modify any of its groups's policies
+    if node_type == 'user':
+        for group in node.group_memberships:
+            group_name = group.arn.split('/')[-1]
+
+            if query_interface.local_check_authorization_handling_mfa(node, 'iam:PutGroupPolicy', group.arn, {})[0]:
+                result.append('Can add/update an inline policy for the group {} (iam:PutGroupPolicy)'.format(group_name))
+
+            if query_interface.local_check_authorization_handling_mfa(node, 'iam:AttachGroupPolicy', group.arn,
+                                                                      condition_keys)[0]:
+                result.append('Can attach the AdministratorAccess policy to the group {} (iam:AttachGroupPolicy)'.format(group_name))
+
+            for attached_policy in group.attached_policies:
+                if attached_policy.arn != group.arn and ':aws:policy/' not in attached_policy.arn:
+                    if query_interface.local_check_authorization_handling_mfa(node, 'iam:CreatePolicyVersion',
+                                                                              attached_policy.arn, {})[0]:
+                        result.append('Can update the managed policy {} that is attached to the group {} (iam:CreatePolicyVersion)'.format(attached_policy.arn, group_name))
+                        break  # reduce output
+
+    return result
+
+
+def compose_wrong_admin_list(graph: Graph) -> List[Tuple[Node, List[str]]]:
+    """Given a Graph, return the collection of principals that are admins but do not have the
+    AdminstratorAccess policy or an equivalent inline policy, along with a list of what policy/policies
+    and statements that could be the source of the admin-access."""
+
+    result = []
+
+    # iterate through all nodes
+    for node in graph.nodes:
+
+        # skip non-admins
+        if not node.is_admin:
+            continue
+
+        # skip principals with Admin or equiv policy
+        flag = False
+        for attached_policy in node.attached_policies:
+            if _is_admin_or_equiv_policy(attached_policy):
+                flag = True
+                break
+        if flag:
+            continue
+
+        # skip IAM Users in IAM Groups with Admin or equiv policy
+        if ':user/' in node.arn:
+            flag = False
+            for group in node.group_memberships:
+                for attached_policy in group.attached_policies:
+                    if _is_admin_or_equiv_policy(attached_policy):
+                        flag = True
+                        break
+                if flag:
+                    break
+            if flag:
+                continue
+
+        # at this point we have a node that's an admin, so let's find the potentially responsible statements
+        result.append((node, _get_admin_reason(node)))
+
+    return result

--- a/principalmapper/querying/query_actions.py
+++ b/principalmapper/querying/query_actions.py
@@ -23,7 +23,7 @@ import re
 from typing import Optional, List
 
 from principalmapper.common import Graph
-from principalmapper.querying.presets import privesc, connected, clusters, endgame, serviceaccess
+from principalmapper.querying.presets import privesc, connected, clusters, endgame, serviceaccess, wrongadmin
 from principalmapper.querying.query_interface import search_authorization_for, search_authorization_full
 from principalmapper.util import arns
 
@@ -45,6 +45,7 @@ Available presets:
     * clusters (tag key)
     * endgame (service|"*")
     * serviceaccess
+    * wrongadmin
 """
 
 
@@ -202,6 +203,8 @@ def handle_preset(graph: Graph, query: str, skip_admins: bool = False) -> None:
         endgame.handle_preset_query(graph, tokens, skip_admins)
     elif tokens[1] == 'serviceaccess':
         serviceaccess.handle_preset_query(graph, tokens, skip_admins)
+    elif tokens[1] == 'wrongadmin':
+        wrongadmin.handle_preset_query(graph, tokens, skip_admins)
     else:
         _print_query_help()
         return
@@ -275,9 +278,11 @@ def argquery(graph: Graph, principal_param: Optional[str], action_param: Optiona
             endgame.handle_preset_query(graph, ['', '', resource_param], skip_admins)
         elif preset_param == 'serviceaccess':
             serviceaccess.handle_preset_query(graph, [], skip_admins)
+        elif preset_param == 'wrongadmin':
+            wrongadmin.handle_preset_query(graph, [], skip_admins)
         else:
             raise ValueError('Parameter for "preset" is not valid. Expected values: "privesc", "connected", '
-                             '"clusters", "endgame", or "serviceaccess".')
+                             '"clusters", "endgame", "serviceaccess", or "wrongadmin".')
 
     else:
         argquery_response(graph, principal_param, action_param, resource_param, condition_param, skip_admins,

--- a/principalmapper/querying/query_interface.py
+++ b/principalmapper/querying/query_interface.py
@@ -309,6 +309,7 @@ def local_check_authorization_full(principal: Node, action_to_check: str, resour
         for policy in iam_group.attached_policies:
             if policy_has_matching_statement(policy, 'Deny', action_to_check, resource_to_check, prepped_condition_keys):
                 logger.debug('Explicit Deny: Principal\'s IAM Group policies')
+                return False
 
     if service_control_policy_groups is not None:
         for service_control_policy_group in service_control_policy_groups:

--- a/tests/test_cross_account_checks.py
+++ b/tests/test_cross_account_checks.py
@@ -1,0 +1,274 @@
+#  Copyright (c) NCC Group and Erik Steringer 2019. This file is part of Principal Mapper.
+#
+#      Principal Mapper is free software: you can redistribute it and/or modify
+#      it under the terms of the GNU Affero General Public License as published by
+#      the Free Software Foundation, either version 3 of the License, or
+#      (at your option) any later version.
+#
+#      Principal Mapper is distributed in the hope that it will be useful,
+#      but WITHOUT ANY WARRANTY; without even the implied warranty of
+#      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#      GNU Affero General Public License for more details.
+#
+#      You should have received a copy of the GNU Affero General Public License
+#      along with Principal Mapper.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Test functions for local resource policy evaluation (S3 bucket policies, IAM Role Trust Docs, etc.)"""
+
+import logging
+import unittest
+
+from tests.build_test_graphs import *
+from tests.build_test_graphs import _build_user_with_policy
+
+from principalmapper.querying.local_policy_simulation import resource_policy_authorization, ResourcePolicyEvalResult, \
+    _statement_matches_action
+from principalmapper.querying.query_interface import local_check_authorization_full, search_authorization_across_accounts
+
+
+class LocalResourcePolicyEvalTests(unittest.TestCase):
+    def test_iam_assume_role(self):
+        """Test that we are correctly validating policies for calls to `sts:AssumeRole`"""
+        trust_doc_1 = {
+            'Version': '2012-10-17',
+            'Statement': [{
+                'Effect': 'Allow',
+                'Principal': {
+                    'AWS': 'arn:aws:iam::000000000000:root'
+                },
+                'Action': 'sts:AssumeRole'
+            }]
+        }
+
+        trust_doc_2 = {
+            'Version': '2012-10-17',
+            'Statement': [{
+                'Effect': 'Allow',
+                'Principal': {
+                    'AWS': 'arn:aws:iam::999999999999:root'
+                },
+                'Action': 'sts:AssumeRole'
+            }]
+        }
+
+        iam_user_1 = _build_user_with_policy(
+            {
+                'Version': '2012-10-17',
+                'Statement': [{
+                    'Effect': 'Allow',
+                    'Action': 'sts:AssumeRole',
+                    'Resource': '*'
+                }]
+            },
+            'single_user_policy',
+            'asdf1',
+            '1'
+        )
+
+        iam_user_2 = _build_user_with_policy(
+            {
+                'Version': '2012-10-17',
+                'Statement': [{
+                    'Effect': 'Allow',
+                    'Action': 's3:GetObject',
+                    'Resource': '*'
+                }]
+            },
+            'single_user_policy',
+            'asdf2',
+            '2'
+        )
+
+        # account root + iam policy => authorized
+        self.assertTrue(
+            local_check_authorization_full(
+                iam_user_1,
+                'sts:AssumeRole',
+                'arn:aws:iam::000000000000:role/test1',
+                {},
+                trust_doc_1,
+                '000000000000'
+            )
+        )
+
+        # iam policy only => not authorized
+        self.assertFalse(
+            local_check_authorization_full(
+                iam_user_1,
+                'sts:AssumeRole',
+                'arn:aws:iam::000000000000:role/test1',
+                {},
+                trust_doc_2,
+                '000000000000'
+            )
+        )
+
+        # account root only => not authorized
+        self.assertFalse(
+            local_check_authorization_full(
+                iam_user_2,
+                'sts:AssumeRole',
+                'arn:aws:iam::000000000000:role/test1',
+                {},
+                trust_doc_1,
+                '000000000000'
+            )
+        )
+
+        # Neither the account root nor the iam policy => not authorized
+        self.assertFalse(
+            local_check_authorization_full(
+                iam_user_2,
+                'sts:AssumeRole',
+                'arn:aws:iam::000000000000:role/test1',
+                {},
+                trust_doc_2,
+                '000000000000'
+            )
+        )
+
+        # A user from another account
+        other_account_node = Node(
+            'arn:aws:iam::999999999999:role/test_other',
+            'ARIA00',
+            [
+                Policy(
+                    'arn:aws:iam::999999999999:role/test_other',
+                    'inline1',
+                    {
+                        'Version': '2012-10-17',
+                        'Statement': [{
+                            'Effect': 'Allow',
+                            'Action': 'sts:AssumeRole',
+                            'Resource': '*'
+                        }]
+                    }
+                )
+            ],
+            [],
+            {},
+            [],
+            0,
+            False,
+            False,
+            None,
+            False,
+            None
+        )
+        self.assertFalse(
+            local_check_authorization_full(
+                other_account_node,
+                'sts:AssumeRole',
+                'arn:aws:iam::000000000000:role/test1',
+                {},
+                trust_doc_1,
+                '000000000000'
+            )
+        )
+
+    def test_match_action_resource_policy_elements(self):
+        """Test if we're correctly testing Action/Resource elements in resource policies"""
+        bucket_policy_1 = {
+            'Version': '2012-10-17',
+            'Statement': [{
+                'Effect': 'Allow',
+                'Principal': '*',
+                'Action': 's3:GetObject',
+                'Resource': 'arn:aws:s3:::bucket/object'
+            }]
+        }
+
+        bucket_policy_2 = {
+            'Version': '2012-10-17',
+            'Statement': [{
+                'Effect': 'Deny',
+                'Principal': '*',
+                'Action': 's3:GetObject',
+                'Resource': 'arn:aws:s3:::bucket/object'
+            }]
+        }
+
+        iam_user_1 = _build_user_with_policy(
+            {
+                'Version': '2012-10-17',
+                'Statement': [{
+                    'Effect': 'Allow',
+                    'Action': 's3:GetObject',
+                    'Resource': 'arn:aws:s3:::bucket/object'
+                }]
+            },
+            'single_user_policy',
+            'asdf1',
+            '1'
+        )
+
+        iam_user_2 = _build_user_with_policy(
+            {
+                'Version': '2012-10-17',
+                'Statement': [{
+                    'Effect': 'Allow',
+                    'Action': 's3:GetObject',
+                    'Resource': 'arn:aws:s3:::bucket/object'
+                }]
+            },
+            'single_user_policy',
+            'asdf2',
+            '2'
+        )
+
+        rpa_result = resource_policy_authorization(
+            iam_user_1,
+            '000000000000',
+            bucket_policy_1,
+            's3:GetObject',
+            'arn:aws:s3:::bucket/object',
+            {}
+        )
+        self.assertTrue(
+            rpa_result == ResourcePolicyEvalResult.NODE_MATCH
+        )
+
+        rpa_result = resource_policy_authorization(
+            iam_user_1,
+            '000000000000',
+            bucket_policy_1,
+            's3:PutObject',
+            'arn:aws:s3:::bucket/object',
+            {}
+        )
+        self.assertTrue(
+            rpa_result == ResourcePolicyEvalResult.NO_MATCH
+        )
+
+    def test_sns_sqs_alternate_action_matching(self):
+        """Test that we handle SNS:... and SQS:... differently with respect to action matching"""
+        self.assertTrue(_statement_matches_action(
+            {
+                'Effect': 'Allow',
+                'Action': 'SQS:CreateQueue',
+                'Resource': '*'
+            },
+            'sqs:CreateQueue',
+            {},
+            True
+        ))
+        self.assertTrue(_statement_matches_action(
+            {
+                'Effect': 'Allow',
+                'Action': 'SNS:CreateTopic',
+                'Resource': '*'
+            },
+            'sns:CreateTopic',
+            {},
+            True
+        ))
+        self.assertFalse(_statement_matches_action(
+            {
+                'Effect': 'Allow',
+                'Action': 'S3:CreateBucket',
+                'Resource': '*'
+            },
+            's3:CreateTopic',
+            {},
+            True
+        ))


### PR DESCRIPTION
- New "wrongadmin" preset query: finds admin users/roles that don't have the AdministratorAccess (or a similar inline policy) set
- Updated admin-checks, cut down on corner-case for potential FPs
- Fixed bug in policy simulator: IAM Group policies with explicit deny were not correctly handled
- Updated policy simulator: AWSServiceRoleFor[...] are now unaffected by SCPs
- Added new test cases