### PR TITLE
Glue Job Edge

### DIFF
--- a/principalmapper/graphing/glue_edges.py
+++ b/principalmapper/graphing/glue_edges.py
@@ -149,45 +149,45 @@ def generate_edges_locally(nodes: List[Node], scps: Optional[List[List[dict]]] =
             # check if source can use existing endpoints to access destination
             if node_destination in node_endpoint_map:
                 for target in node_endpoint_map[node_destination]:
-                    update_ep_auth, update_ep_needs_mfa = query_interface.local_check_authorization_handling_mfa(
-                        node_source,
-                        'glue:UpdateDevEndpoint',
-                        target,
-                        {},
-                        service_control_policy_groups=scps
-                    )
-                    if update_ep_auth:
-                        if update_ep_needs_mfa:
-                            reason = f'(requires MFA) can use the Glue resource {target} to access'
-                        else:
-                            reason = f'can use the Glue resource {target} to access'
-                        results.append(Edge(
+                    if ':devEndpoint/' in target:
+                        update_ep_auth, update_ep_needs_mfa = query_interface.local_check_authorization_handling_mfa(
                             node_source,
-                            node_destination,
-                            reason,
-                            'Glue'
-                        ))
-                        break
+                            'glue:UpdateDevEndpoint',
+                            target,
+                            {},
+                            service_control_policy_groups=scps
+                        )
+                        if update_ep_auth:
+                            if update_ep_needs_mfa:
+                                reason = f'(requires MFA) can use the Glue resource {target} to access'
+                            else:
+                                reason = f'can use the Glue resource {target} to access'
+                            results.append(Edge(
+                                node_source,
+                                node_destination,
+                                reason,
+                                'Glue'
+                            ))
 
-                    update_job_auth, update_job_needs_mfa = query_interface.local_check_authorization_handling_mfa(
-                        node_source,
-                        'glue:UpdateJob',
-                        target,
-                        {},
-                        service_control_policy_groups=scps
-                    )
-                    if update_job_auth:
-                        if update_job_needs_mfa:
-                            reason = f'(requires MFA) can use the Glue resource {target} to access'
-                        else:
-                            reason = f'can use the Glue resource {target} to access'
-                        results.append(Edge(
+                    if ':job/' in target:
+                        update_job_auth, update_job_needs_mfa = query_interface.local_check_authorization_handling_mfa(
                             node_source,
-                            node_destination,
-                            reason,
-                            'Glue'
-                        ))
-                        break
+                            'glue:UpdateJob',
+                            target,
+                            {},
+                            service_control_policy_groups=scps
+                        )
+                        if update_job_auth:
+                            if update_job_needs_mfa:
+                                reason = f'(requires MFA) can use the Glue resource {target} to access'
+                            else:
+                                reason = f'can use the Glue resource {target} to access'
+                            results.append(Edge(
+                                node_source,
+                                node_destination,
+                                reason,
+                                'Glue'
+                            ))
 
             # check if source can create a new endpoint to access destination
             passrole_auth, passrole_needs_mfa = query_interface.local_check_authorization_handling_mfa(


### PR DESCRIPTION
Glue Jobs are missed edges currently.

The `glue:CreateJob` privilege can be used to create a new job with an associated role. Similarly the `glue:UpdateJob`  privilege can be used to update existing jobs.

This technique is a bit quicker to abuse than dev endpoints as the dev endpoints take a few minutes to spin up.

#### Create a Job
```
# Copy the job code into an S3 bucket
$ aws s3 cp job.py s3://bucket/job.py

# Create the job
$ aws glue create-job --name glue-job --role arn:aws:iam::000000000000:role/Glue-Admin --command Name=pythonshell,ScriptLocation=s3://bucket/job.py,PythonVersion=3

# Run the job
$ aws glue start-job-run --job-name glue-job
```

#### Update an existing job
```
$ aws glue update-job --job-name glue-job --job-update 'Role=arn:aws:iam::000000000000:role/Glue-Admin,Command={Name=pythonshell,ScriptLocation=s3://bucket/job.py,PythonVersion=3}'
```