### PR TITLE
Update case_insensitive_dict.py

### DIFF
--- a/principalmapper/util/case_insensitive_dict.py
+++ b/principalmapper/util/case_insensitive_dict.py
@@ -31,8 +31,8 @@
 #      See the License for the specific language governing permissions and
 #      limitations under the License.
 
-from collections import Mapping, MutableMapping, OrderedDict
-
+from collections.abc import Mapping, MutableMapping
+from collections import OrderedDict
 
 class CaseInsensitiveDict(MutableMapping):
     """A case-insensitive ``dict``-like object.


### PR DESCRIPTION
Please note that there is a change to the collections module in Python 3.10. This fixes the modules for Python 3.10. It may however break older builds of python3, unsure how to resolve that particular issue.